### PR TITLE
Add department filter to employees table

### DIFF
--- a/src/features/employees/presentation/pages/EmployeesPage.tsx
+++ b/src/features/employees/presentation/pages/EmployeesPage.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { useGetEmployeesQuery } from "../../data/employeesApi";
+import { useMemo, useState } from "react";
+import { useGetEmployeesQuery, useGetDepartmentsQuery } from "../../data/employeesApi";
 import { EmployeesTable } from "../components/EmployeesTable";
 import { EmployeeCreateForm } from "../components/EmployeeCreateForm";
 
@@ -9,7 +9,17 @@ interface EmployeesPageProps {
 
 export function EmployeesPage({ onSelectEmployee }: EmployeesPageProps) {
   const [showForm, setShowForm] = useState(false);
+  const [selectedDepartment, setSelectedDepartment] = useState("All");
   const { data: employees = [], isLoading, error } = useGetEmployeesQuery();
+  const { data: departments = [] } = useGetDepartmentsQuery();
+
+  const filteredEmployees = useMemo(
+    () =>
+      selectedDepartment === "All"
+        ? employees
+        : employees.filter((e) => e.department === selectedDepartment),
+    [employees, selectedDepartment],
+  );
 
   if (isLoading) {
     return (
@@ -39,7 +49,7 @@ export function EmployeesPage({ onSelectEmployee }: EmployeesPageProps) {
           <div>
             <h2 className="text-xl font-bold text-white md:text-2xl">Employees</h2>
             <p className="mt-1 text-sm text-blue-100">
-              Manage your team — {employees.length} member{employees.length !== 1 && "s"} and counting.
+              Manage your team — {filteredEmployees.length} member{filteredEmployees.length !== 1 && "s"} and counting.
             </p>
           </div>
           <button
@@ -60,7 +70,26 @@ export function EmployeesPage({ onSelectEmployee }: EmployeesPageProps) {
         </div>
       )}
 
-      <EmployeesTable employees={employees} onSelectEmployee={onSelectEmployee} />
+      <div className="mb-4 flex items-center gap-3">
+        <label htmlFor="department-filter" className="text-sm font-medium text-gray-700">
+          Department
+        </label>
+        <select
+          id="department-filter"
+          value={selectedDepartment}
+          onChange={(e) => setSelectedDepartment(e.target.value)}
+          className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+          <option value="All">All</option>
+          {departments.map((dept) => (
+            <option key={dept.id} value={dept.name}>
+              {dept.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <EmployeesTable employees={filteredEmployees} onSelectEmployee={onSelectEmployee} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a department dropdown filter above the employees table using the existing `useGetDepartmentsQuery` hook
- Filters the table in real-time when a department is selected
- Defaults to "All" showing every employee

Closes #1

## Test plan
- [ ] Verify the dropdown loads all departments from the API
- [ ] Select a specific department and confirm the table only shows matching employees
- [ ] Select "All" and confirm all employees are displayed
- [ ] Verify the header employee count updates to reflect the filtered list

🤖 Generated with [Claude Code](https://claude.com/claude-code)